### PR TITLE
Fix void elements that libxml2 does not know

### DIFF
--- a/inc/namespace.php
+++ b/inc/namespace.php
@@ -161,6 +161,15 @@ function enable_lightbox_for_images( string $content ): string {
 		$content = $document_html;
 	}
 
+	// Remove stray end tags of void elements libxml2 does not know.
+	$stray_end_tags = [
+		'</embed>',
+		'</source>',
+		'</track>',
+		'</wbr>',
+	];
+	$content        = str_replace( $stray_end_tags, '', $content );
+
 	// phpcs:enable WordPress.NamingConventions.ValidVariableName.UsedPropertyNotSnakeCase
 
 	if ( $lightboxes > 0 && ! wp_script_is( 'required-tobii-integration' ) ) {


### PR DESCRIPTION
libxml2 has some problems with void elements, it does not know. In these cases, it will add stray end tags that are not needed.

- [List of elements known to libxml2](https://github.com/GNOME/libxml2/blob/40abebbc739fb4cddfc205eeb129cefe9b9f6e5b/fuzz/html.dict#L6)
- [List of void elements](https://developer.mozilla.org/en-US/docs/Glossary/Void_element)

The missing elements are:
- embed
- source
- track
- wbr

In most cases, this does not lead to visible problems because browsers will still be able to interpret the source code correctly. However, this still leads to invalid HTML and is not a desired side effect of our plugin.

The easiest, straight-forward approach would be just removing the stray end tags afterwards.

### Reproduction

- Create a new WordPress post and add `<source>` to the content.
- You will see in the source code that a stray end tag was added.
- With this feature branch the end tag should be correctly removed again.